### PR TITLE
Fix import example

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,6 +478,8 @@ This is an initial draft of a CloudFormation template style guide. The intent is
     ##############
     # Template importing config-stack values:
     Parameters:
+      Environment:
+        Type: String
       BucketName:
         Type: String
 
@@ -485,9 +487,7 @@ This is an initial draft of a CloudFormation template style guide. The intent is
       S3Bucket:
         Type: AWS::S3::Bucket
         Properties:
-          BucketName:
-            Fn::ImportValue:
-              !Sub ${Environment}-${BucketName}
+          BucketName: !Join [ '-', [ 'Fn::ImportValue': !Sub '${Environment}-resource-prefix', !Ref BucketName ]]
     ```
 
 ## Attribution


### PR DESCRIPTION
The example doesn't work; `Environment` needs to be a parameter, and the import value key wasn't correct.

This works. Maybe I totally misunderstand the original intention. If so, I'd be curious to know how it should work otherwise.